### PR TITLE
feat: cleanup tmp files on restart

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,10 +2,10 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1687412861,
-        "narHash": "sha256-Z/g0wbL68C+mSGerYS2quv9FXQ1RRP082cAC0Bh4vcs=",
-        "path": "/nix/store/s1z7nb9n6r5n0r34fabp6yybwkbr8mjk-source",
-        "rev": "e603dc5f061ca1d8a19b3ede6a8cf9c9fcba6cdc",
+        "lastModified": 1687502512,
+        "narHash": "sha256-dBL/01TayOSZYxtY4cMXuNCBk8UMLoqRZA+94xiFpJA=",
+        "path": "/nix/store/h26619k1aq8xj025905p5qqsxj8xdcmm-source",
+        "rev": "3ae20aa58a6c0d1ca95c9b11f59a2d12eebc511f",
         "type": "path"
       },
       "original": {


### PR DESCRIPTION
Cleanup tmp files on restart. 
Removes temporary disks and share on start/stop of the vm process.

fixes #4 